### PR TITLE
Proposed solution to support primitive wrapper types in XML syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -266,7 +266,7 @@ Live your life as usual, no crazy `yield`s to debug :).
 # Tagfile style invocation
 
 You can also invoke a template using a XML tag syntax. In this mode, all
-parameters should be `String` and are considered optional.
+parameters should be `String` or a primitive wrapper (`Integer`, `Boolean` etc, except `Character`) and are considered optional.
 
 ```
 <tone:header title="MyTitle"/>
@@ -293,9 +293,7 @@ The generated code looks like this:
 <% }).done(); %>
 ```
 
-Please note that all arguments are optional and `String`, except the body tag.
-
-This tag invocation syntax is still compile safe, but in a different manner. 
+This tag invocation syntax is still compile safe, but in a different way. 
 With tag syntax, the compiler will check types and parameter names, but order and quantity doesn't matter.
 With the usual Java invocation syntax, the compiler checks types, order and parameter quantity, but not parameter names.
 So both syntaxes have its strengths and weakness. Choose the one that better fit you case by case.  

--- a/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
+++ b/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
@@ -3,6 +3,7 @@ package br.com.caelum.vraptor.panettone;
 import static java.util.stream.Collectors.joining;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -101,6 +102,13 @@ public class VRaptorCompilationListener implements CompilationListener {
 			
 			code.append("private " + type + " " + name + ";\n");
 			code.append("public " + typeName + " " + name + "("+ type + " " + name +") { this."+name+" = " + name + "; return this; }\n");
+			
+			
+			final List<String> WRAPPERS = Arrays.asList(new String[]{"Integer", "Boolean", "Double", "Long", "Byte", "Short", "Float"});
+			
+			if (!type.equals("String") && WRAPPERS.contains(type)) {
+				code.append("public " + typeName + " " + name + "(String " + name +") { this."+name+" = " + type + ".valueOf(" + name + "); return this; }\n");
+			}
 			
 			doneParams.add(name);
 		});

--- a/src/test/java/br/com/caelum/vraptor/panettone/TemplateTest.java
+++ b/src/test/java/br/com/caelum/vraptor/panettone/TemplateTest.java
@@ -472,6 +472,23 @@ public class TemplateTest {
 	}
 	
 	@Test
+	public void shouldIncludeBuilderForBooleanVariable() {
+		String expected = "public void render(Boolean message) {\n"
+				+ "// line 1\n"
+				+ "// line 2\n"
+				+ "write(\"<html>\");\n"
+				+ "write(message);\n"
+				+ "write(\"</html>\");\n"
+				+ "}\n"
+				+ "private Boolean message;\n"
+				+ "public header message(Boolean message) { this.message = message; return this; }\n"
+				+ "public header message(String message) { this.message = Boolean.valueOf(message); return this; }\n"
+				+ "public void done() { render(message); }\n";
+		String result = new Template("(@Boolean message )\n<html><%= message %></html>", new VRaptorCompilationListener()).renderType("header");
+		assertEquals(expected, result);
+	}
+	
+	@Test
 	public void shouldIncludeBuilderForMultipleVariables() {
 		String expected = "public void render(String message,String title) {\n"
 				+ "// line 1\n"

--- a/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
+++ b/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
@@ -76,6 +76,39 @@ public class VRaptorCompilationListenerTest {
 	}
 	
 	@Test
+	public void shouldIncludeSpecialBuilderForBooleanVariable() {
+		String expected = 
+				  "private Boolean flag;\n"
+				+ "public header flag(Boolean flag) { this.flag = flag; return this; }\n"
+				+ "public header flag(String flag) { this.flag = Boolean.valueOf(flag); return this; }\n"
+				+ "public void done() { render(flag); }\n";
+		String result = new VRaptorCompilationListener().useParameters(Arrays.asList("Boolean flag"), "header");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldIncludeSpecialBuilderForIntegerVariable() {
+		String expected = 
+				  "private Integer flag;\n"
+				+ "public header flag(Integer flag) { this.flag = flag; return this; }\n"
+				+ "public header flag(String flag) { this.flag = Integer.valueOf(flag); return this; }\n"
+				+ "public void done() { render(flag); }\n";
+		String result = new VRaptorCompilationListener().useParameters(Arrays.asList("Integer flag"), "header");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldIncludeSpecialBuilderForDoubleVariable() {
+		String expected = 
+				  "private Double flag;\n"
+				+ "public header flag(Double flag) { this.flag = flag; return this; }\n"
+				+ "public header flag(String flag) { this.flag = Double.valueOf(flag); return this; }\n"
+				+ "public void done() { render(flag); }\n";
+		String result = new VRaptorCompilationListener().useParameters(Arrays.asList("Double flag"), "header");
+		assertEquals(expected, result);
+	}
+	
+	@Test
 	public void shouldIncludeBuilderForMultipleVariables() {
 		String expected = 
 				  "private String message;\n"


### PR DESCRIPTION
The first release of the `<tone:tag />` syntax only supports `String` for parameters. I have a few use cases where being able to use some `Boolean`s would be nice:

```
<tone:tag flag="true" />
```

(today this only works with `(@String flag)` and manually calling `Boolean.parseBoolean`)

This propose adds a conversion method to the builder that calls `Boolean.parseBoolean` for me.

One major drawback is that we loose static *value* checking (no way to know if you type a valid value). So we can get parsing exceptions on production (like `NumberFormatException`).

----

P.S. Please note that it isn't possible to generate the proper method invocation without the parsing call with panettone. To do that, the invocation point would need access to the declaring type, which isn't supported.