### PR TITLE
Propose to allow code invocations inside XML syntax

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -277,6 +277,17 @@ The generated code looks like this:
 <% use(header.class).title("MyTitle").done(); %>
 ```
 
+You can invoke code inside parameters using `@`. Please note that it's direct code, not EL.
+
+```
+<tone:header title="@title" description="@obj.getDescription()" />
+```
+
+The generated code looks like this:
+```
+<% use(header.class).title(title).description(obj.getDescription()).done(); %>
+```
+
 It's possible to include a body in your tag. In this case, the parameter should
 always be `Runnable body`:
 

--- a/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
+++ b/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
@@ -49,12 +49,14 @@ public class VRaptorCompilationListener implements CompilationListener {
 	private static final String OPEN_TAG_REGEX = "^<tone:([^\\s>]+)\\s*";
 	private static final String SELF_CLOSING_TAG_REGEX = "/>$";
 	private static final String TAG_REMAINS_OPEN_REGEX = ">$";
-	private static final String TAG_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*(\"[^\"]*\")\\s*";
+	private static final String TAG_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"([^\"]*)\"\\s*";
+	private static final String TAG_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"@([^\"]*)\"\\s*";
 	private static final String CLOSING_TAG_REGEX = "</tone:[^>]+>";
 	
 	private static final String OPEN_INVOCATION_PART = "<%use($1.class)";
 	private static final String CLOSE_INVOCATION_PART = ".done();%>";
-	private static final String INVOKE_BUILDER_METHOD_PART = ".$1($2)";
+	private static final String INVOKE_BUILDER_METHOD_WITH_STRING_PART = ".$1(\"$2\")";
+	private static final String INVOKE_BUILDER_METHOD_WITH_CODE_PART = ".$1($2)";
 	private static final String OPEN_BODY_PART = ".body(()->{%>\n";
 	private static final String CLOSE_BODY_PART = "\n<%}).done();%>";
 	
@@ -76,7 +78,8 @@ public class VRaptorCompilationListener implements CompilationListener {
 				tag = tag.replaceFirst(TAG_REMAINS_OPEN_REGEX, OPEN_BODY_PART);
 			}
 			
-			tag = tag.replaceAll(TAG_PARAM_REGEX, INVOKE_BUILDER_METHOD_PART);
+			tag = tag.replaceAll(TAG_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
+			tag = tag.replaceAll(TAG_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
 			
 		    m.appendReplacement(sb, tag);
 		}

--- a/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
+++ b/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
@@ -23,6 +23,27 @@ public class VRaptorCompilationListenerTest {
 	}
 	
 	@Test
+	public void shouldSupportXMLSyntaxWithCodeParam() {
+		String expected = "<html><%use(header.class).title(title).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@title\" /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithComplexCodeParam() {
+		String expected = "<html><%use(header.class).title(obj.getTitle()).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@obj.getTitle()\" /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldNotSupportXMLSyntaxWithELSyntaxParam() {
+		String expected = "<html><%use(header.class).title(obj.title).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@obj.title\" /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
 	public void shouldSupportXMLSyntaxWithMultipleParam() {
 		String expected = "<html><%use(header.class).title(\"MyTitle\").description(\"Desc\").done();%></html>";
 		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"MyTitle\" description=\"Desc\"/></html>");


### PR DESCRIPTION
Currently, the XML syntax only allows static values on attributes. But in many scenarios, the value can come from some variable or other code.

This PR extends the XML syntax to support special attributes (value prefixes with `@`) that include Java code.

```
<tone:header title="@title" />
```

Please note that the code isn't evaluated or validated in any way. The value is passed directly to the source output. Also note that I didn't implement an EL parser, so `obj.title` isn't transformed in `obj.getTitle()`.