### PR TITLE
Support single quotes on XML syntax

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
+++ b/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
@@ -51,7 +51,9 @@ public class VRaptorCompilationListener implements CompilationListener {
 	private static final String SELF_CLOSING_TAG_REGEX = "/>$";
 	private static final String TAG_REMAINS_OPEN_REGEX = ">$";
 	private static final String TAG_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"([^\"]*)\"\\s*";
+	private static final String TAG_SINGLE_QUOTED_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\'([^\']*)\'\\s*";
 	private static final String TAG_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"@([^\"]*)\"\\s*";
+	private static final String TAG_SINGLE_QUOTED_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\'@([^\']*)\'\\s*";
 	private static final String CLOSING_TAG_REGEX = "</tone:[^>]+>";
 	
 	private static final String OPEN_INVOCATION_PART = "<%use($1.class)";
@@ -80,7 +82,9 @@ public class VRaptorCompilationListener implements CompilationListener {
 			}
 			
 			tag = tag.replaceAll(TAG_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
+			tag = tag.replaceAll(TAG_SINGLE_QUOTED_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
 			tag = tag.replaceAll(TAG_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
+			tag = tag.replaceAll(TAG_SINGLE_QUOTED_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
 			
 		    m.appendReplacement(sb, tag);
 		}

--- a/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
+++ b/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
@@ -50,16 +50,14 @@ public class VRaptorCompilationListener implements CompilationListener {
 	private static final String OPEN_TAG_REGEX = "^<tone:([^\\s>]+)\\s*";
 	private static final String SELF_CLOSING_TAG_REGEX = "/>$";
 	private static final String TAG_REMAINS_OPEN_REGEX = ">$";
-	private static final String TAG_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"([^\"]*)\"\\s*";
-	private static final String TAG_SINGLE_QUOTED_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\'([^\']*)\'\\s*";
-	private static final String TAG_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\"@([^\"]*)\"\\s*";
-	private static final String TAG_SINGLE_QUOTED_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*\'@([^\']*)\'\\s*";
+	private static final String TAG_PARAM_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)')\\s*";
+	private static final String TAG_PARAM_WITH_CODE_REGEX = "\\s*([\\w_\\-\\d]+)\\s*=\\s*(?:\"@([^\"]*)\"|'@([^']*)')\\s*";
 	private static final String CLOSING_TAG_REGEX = "</tone:[^>]+>";
 	
 	private static final String OPEN_INVOCATION_PART = "<%use($1.class)";
 	private static final String CLOSE_INVOCATION_PART = ".done();%>";
-	private static final String INVOKE_BUILDER_METHOD_WITH_STRING_PART = ".$1(\"$2\")";
-	private static final String INVOKE_BUILDER_METHOD_WITH_CODE_PART = ".$1($2)";
+	private static final String INVOKE_BUILDER_METHOD_WITH_STRING_PART = ".$1(\"$2$3\")";
+	private static final String INVOKE_BUILDER_METHOD_WITH_CODE_PART = ".$1($2$3)";
 	private static final String OPEN_BODY_PART = ".body(()->{%>\n";
 	private static final String CLOSE_BODY_PART = "\n<%}).done();%>";
 	
@@ -82,9 +80,7 @@ public class VRaptorCompilationListener implements CompilationListener {
 			}
 			
 			tag = tag.replaceAll(TAG_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
-			tag = tag.replaceAll(TAG_SINGLE_QUOTED_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
 			tag = tag.replaceAll(TAG_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
-			tag = tag.replaceAll(TAG_SINGLE_QUOTED_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
 			
 		    m.appendReplacement(sb, tag);
 		}

--- a/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
+++ b/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
@@ -23,6 +23,13 @@ public class VRaptorCompilationListenerTest {
 	}
 	
 	@Test
+	public void shouldSupportXMLSyntaxWithSimpleQuotedParam() {
+		String expected = "<html><%use(header.class).title(\"MyTitle\").done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title='MyTitle' /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
 	public void shouldSupportXMLSyntaxWithCodeParam() {
 		String expected = "<html><%use(header.class).title(title).done();%></html>";
 		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@title\" /></html>");
@@ -33,6 +40,20 @@ public class VRaptorCompilationListenerTest {
 	public void shouldSupportXMLSyntaxWithComplexCodeParam() {
 		String expected = "<html><%use(header.class).title(obj.getTitle()).done();%></html>";
 		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@obj.getTitle()\" /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithComplexCodeAndSingleQuotedParam() {
+		String expected = "<html><%use(header.class).title(obj.getTitle()).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title='@obj.getTitle()' /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithComplexCodeAndStringInASingleQuotedParam() {
+		String expected = "<html><%use(header.class).title(\"Title: \" + obj.getTitle()).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title='@\"Title: \" + obj.getTitle()' /></html>");
 		assertEquals(expected, result);
 	}
 	
@@ -50,6 +71,12 @@ public class VRaptorCompilationListenerTest {
 		assertEquals(expected, result);
 	}
 
+	@Test
+	public void shouldSupportXMLSyntaxWithMultipleSingleQuotedParams() {
+		String expected = "<html><%use(header.class).title(\"MyTitle\").description(\"Desc\").done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title='MyTitle' description='Desc'/></html>");
+		assertEquals(expected, result);
+	}
 
 	@Test
 	public void shouldSupportXMLSyntaxWithEmptyBody() {


### PR DESCRIPTION
Adds support for single quoting attribute values:

```
<tone:header title='My Title'/>
```

This is specially useful when using a code parameter with a Java String concatenation:

```
<tone:header title='@"My Title: " + title'/>
```