### PR TITLE
Support tone:rendered parameter

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
+++ b/src/main/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListener.java
@@ -61,6 +61,8 @@ public class VRaptorCompilationListener implements CompilationListener {
 	private static final String OPEN_BODY_PART = ".body(()->{%>\n";
 	private static final String CLOSE_BODY_PART = "\n<%}).done();%>";
 	
+	private static final String RENDERED_PARAM_WITH_CODE_REGEX = "\\s*tone:rendered\\s*=\\s*(\"@[^\"]*\"|'@[^']*')\\s*";
+	
 	@Override
 	public String preprocess(String content) {
 		
@@ -70,6 +72,14 @@ public class VRaptorCompilationListener implements CompilationListener {
 		 
 		while (m.find()) {
 			String tag = m.group();
+			
+			String rendered = "";
+			Matcher renderedMatcher = Pattern.compile(RENDERED_PARAM_WITH_CODE_REGEX).matcher(tag);
+			if (renderedMatcher.find()) {
+				String renderedParam = renderedMatcher.group(1);
+				rendered = "<%if("+renderedParam.substring(2,renderedParam.length()-1)+")%>";
+				tag = tag.replaceFirst(RENDERED_PARAM_WITH_CODE_REGEX, " ");
+			}
 			
 			tag = tag.replaceFirst(OPEN_TAG_REGEX, OPEN_INVOCATION_PART);
 
@@ -82,7 +92,7 @@ public class VRaptorCompilationListener implements CompilationListener {
 			tag = tag.replaceAll(TAG_PARAM_WITH_CODE_REGEX, INVOKE_BUILDER_METHOD_WITH_CODE_PART);
 			tag = tag.replaceAll(TAG_PARAM_REGEX, INVOKE_BUILDER_METHOD_WITH_STRING_PART);
 			
-		    m.appendReplacement(sb, tag);
+		    m.appendReplacement(sb, rendered + tag);
 		}
 		m.appendTail(sb);
 		content = sb.toString();

--- a/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
+++ b/src/test/java/br/com/caelum/vraptor/panettone/VRaptorCompilationListenerTest.java
@@ -16,9 +16,43 @@ public class VRaptorCompilationListenerTest {
 	}
 	
 	@Test
+	public void shouldSupportXMLSyntaxWithSimpleRendered() {
+		String expected = "<%if(true)%><%use(header.class).done();%>";
+		String result = new VRaptorCompilationListener().preprocess("<tone:header tone:rendered=\"@true\" />");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithSingleQuotedRendered() {
+		String expected = "<%if(\"string\".isEmpty())%><%use(header.class).done();%>";
+		String result = new VRaptorCompilationListener().preprocess("<tone:header tone:rendered='@\"string\".isEmpty()' />");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldNotSupportXMLSyntaxWithSimpleRenderedWithoutAtSign() {
+		String result = new VRaptorCompilationListener().preprocess("<tone:header tone:rendered=\"true\" />");
+		assertFalse(result.contains("<%if"));
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithComplexRendered() {
+		String expected = "<%if(list.isEmpty())%><%use(header.class).done();%>";
+		String result = new VRaptorCompilationListener().preprocess("<tone:header tone:rendered=\"@list.isEmpty()\" />");
+		assertEquals(expected, result);
+	}
+	
+	@Test
 	public void shouldSupportXMLSyntaxWithParam() {
 		String expected = "<html><%use(header.class).title(\"MyTitle\").done();%></html>";
 		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"MyTitle\" /></html>");
+		assertEquals(expected, result);
+	}
+	
+	@Test
+	public void shouldSupportXMLSyntaxWithCodeParamAndRendered() {
+		String expected = "<html><%if(list.isEmpty())%><%use(header.class).title(title).done();%></html>";
+		String result = new VRaptorCompilationListener().preprocess("<html><tone:header title=\"@title\" tone:rendered=\"@list.isEmpty()\" /></html>");
 		assertEquals(expected, result);
 	}
 	


### PR DESCRIPTION
This PR adds a new tone:rendered attribute that expects a boolean expression. If true, the component is called, otherwise it’s ignored.

```
<tone:component tone:rendered="@list.isEmpty()" />
```

Will output this Java code:

```
if (list.isEmpty()) use(component.class).render();
```